### PR TITLE
S3 bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ jobs:
     - pip install pytest
     - python -m pytest
   - stage: deploy
+    if: branch = master AND (NOT type IN (pull_request))
     services:
     - docker
-    if: branch = master AND (NOT type IN (pull_request))
+    before_install:
+    - openssl aes-256-cbc -K $encrypted_ef6e0359b415_key -iv $encrypted_ef6e0359b415_iv
+      -in kubeconfig.enc -out kubeconfig -d
+    - npm i -g npm@6.6.0
     language: node_js
     node_js:
     - '8'
@@ -30,7 +34,3 @@ env:
   - secure: nXKI3VzCL4k3OXyVbVEwGDrUCnBXPQ8a/0mkx1dOhnvmASYuImBLsMlYZvVdAyuSYfQqQLIDxQwGkgfUA3jZqEZvHz6C7CK3ENIXlkNmr+cOPDBq6drpgw75Ju6MZoreDcEKdOSurFsM3dTk9jE1QGJeqkO7x7E/l81iLxccfDt1ZNVfah6MRYeqss4hMBkAADkz3XkmCaUjHp8OO+wNry8XdRMiArloyAL65oCVjgWBEFiUvO2IMx6sHVskV5Kvfi0ftAMhd+h2knwodq2sgdx6pJqzF/0+3Qw6iEtQ8U3zJgmfvugkd7ZVME3JP+w49VHTfJubZyp5s5xHaqU4DpVxPWVj/cyAKC4Wy9Yax+AoP6K3uuSOfYSIGaFETjqs6cmgcDSDhXvZHbcPSSF8ZcW308IupOHrHzNWWBUzrnxgbyaHY8ua8lkq90W7DCJVhA8lG55qRx5gSrambB3V+VeN4mqs2cvjk88655vVItR1sT5LK974bFPhCxNe79r2Z8NU1BqOQCkN3nl1YZH7LmHNbfRbF8RcVGLfr0hY1mtf2SHHDsBcNu5++FWGFeRJiucsE2SVd2443AFw0BbACg7HtRgg18DHb3Z0+5AnZsoBRLDSRR9HJVbagdfrIF+bLacxp6jtigfsJstKprF29WVUYAnse2XbAaRof4Vtc0k=
   - secure: ZDktb8uzJSUX4QZJBQYJulX977gLF4+Q8hD8f45EAi8v2NunmMxLFt/Jp7qLPiJm7c08lsoudvc1O2a7OyArhqRqCsM86Fs8jheyeq7q+oz0keh0V17A6QJLJoteJHygJt95lGHV9K8zvzXmWLLe1IEmO28vbRL1xMtj5ult99bBAr15R9LzUbgFfRQhSpUVWnk/eatdrN500YNwvZtTiJ5YptcC4SKlCMiB1v/jQT3nIzRlOlP1zXQmF41Whaze//T6XeFQd+dgC5Y2aR4hEZTBiuTLn1AixfwEEczuWGBI1huh2ijgsgVSxIUqb8E0X1KGSmFKTreIyGDGWdVr7r1yglBPaC53mR0XLFnFH3OOb7TGBZfHGvvMh5kDXSanq+M7GXtedv+VRevVeEX9QMUINemlD0IRnmQ+mv7QtN+CrlKjfCFuE9XUzzORBIdwc5s114OB7noqFnyDRnu9Ja/gODkkNtycGMLmUP+cUovvlVHT4wlgeA2qOlpYchrXPCenxVCY8l+Yde0iPKC+OYpphZDuoNh/VQmzk1z0v2hYekRBM+speZoP4h8n1OxceZPnfTodJgVNVHko9CVm8kDLkwN3418Cn12wu5xS9CtVEB04MxlXpZ5RR5MUmU1ITdUTnNhZGmkDEZLdMAdlxgIi6bB5EFPwrgfH2q0NcpI=
   - secure: g2AdmXWlvhqLAqHE3PzseDqz9UttZtjJp4jlTbArOB+c3Qjeu5Sogx3UijATAryJtCegqu7Tz59FBlyeDs1JPGK+4XkypP7eisIieaHn7stXAuU0/K8O3eXBCEPV60EUzZ1uM6ZlI6ragnaWgE9KAN3/chR7sHlobHe6dd59TEIvVf0gcOU1xEfrNozdfbI63L3Ug2oEF2l4o6J/XtEpdMHJcMWST/vYp2jmge8z+fTXb0LaWKLD+XpEsGRoeK1oZPUANahQzQygdfdNptYRvoh9TJuEbAiNz5dVyFBUue/7XJo9gMO2qV5d6Mhk0MMswoR7hQ4PNM1LfkleeeIscKwI1wd1TT69pZkeyLQ9SyK7phsn2iNbkNpPSyNWm79NJB1S/JJrV/pC+WbZcxaMiMQ7XZ+gRm39ixflHI9UT1O1GwpGapqdKzk+T1GmtSF1twbf3xivvMJt1hu6NdV0qdaeiXNnHuXrbpivN8Ch4RBACjZUW1y5kS2j5G0XVrZuurWe3H6NHscsgkvX1nNJTcZ11q2RiUy1DJx2r5ealj/9eFdxkjoE5klcuZ30hLqUCakwPKwygwOT874b8az9aUgYlhEkNexw5FKgFLdWhO9tNadRwsJw51WYM501BGQLsvn0Ft9xPzzQUrf6mzgSho94lHnos8zi5iO9TWV6bnc=
-before_install:
-- openssl aes-256-cbc -K $encrypted_ef6e0359b415_key -iv $encrypted_ef6e0359b415_iv
-  -in kubeconfig.enc -out kubeconfig -d
-- npm i -g npm@6.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ FROM python
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
 
 # Install production dependencies.
-RUN pip install Flask
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
 
 # Service must listen to $PORT environment variable.
 # This default value facilitates local development.

--- a/app/handlers/http.py
+++ b/app/handlers/http.py
@@ -2,7 +2,7 @@ from flask import request
 from flask_restplus import Resource, Namespace
 from app.resources.schemas import example, bucket_file
 from app.service.crud import get_all_examples, save_example, get_example
-from app.service.bucket import list_files, get_upload_url
+from app.service.bucket import list_files, get_upload_url, get_download_url
 
 api = Namespace('example', description='example related operations')
 api._path = '/'
@@ -79,3 +79,11 @@ class BucketOperations(Resource):
             return get_upload_url(public_id, data['file_name'])
         except Exception as e:
             return api.abort(500, e)
+
+@api.route('/<public_id>/buckets/<file_name>')
+@api.param('public_id', 'The user identifier')
+@api.param('file_name', 'A file name')
+class BucketFileOperations(Resource):
+    @api.doc('get download link for file')
+    def get(self, public_id, file_name):
+        return get_download_url(public_id, file_name)

--- a/app/resources/schemas.py
+++ b/app/resources/schemas.py
@@ -6,3 +6,7 @@ example = {
     'username': fields.String(required=True, error_message='username is required'),
     'password': fields.String(required=True, load_only=True, error_message='password is required')
 }
+
+bucket_file = {
+    'file_name': fields.String(required=True, error_message='file name is required to receive an upload link')
+}

--- a/app/service/bucket.py
+++ b/app/service/bucket.py
@@ -18,10 +18,19 @@ client = session.client('s3',
 
 def get_upload_url(user_id, file_name, bucket=bucket_name):
     key = 'users/{user_id}/uploads/{file_name}'.format(user_id=user_id, file_name=file_name)
-    url = client.generate_presigned_url('put_object',
+    url = client.generate_presigned_url(ClientMethod='put_object',
                                         Params={'Bucket': bucket, 'Key':key},
                                         ExpiresIn=bucket_url_expiration,
                                         HttpMethod='PUT')
+    return url
+
+def get_download_url(user_id, file_name, bucket=bucket_name):
+    key = 'users/{user_id}/uploads/{file_name}'.format(user_id=user_id, file_name=file_name)
+    # Generate the URL to get 'key-name' from 'bucket-name'
+    url = client.generate_presigned_url(ClientMethod='get_object',
+                                    Params={ 'Bucket': bucket_name, 'Key': key},
+                                    ExpiresIn=bucket_url_expiration,
+                                    HttpMethod='GET')
     return url
 
 def list_files(user_id, bucket=bucket_name):

--- a/app/service/bucket.py
+++ b/app/service/bucket.py
@@ -1,0 +1,39 @@
+import os
+import boto3
+
+region_name = os.getenv('BUCKET_REGION', 'sfo2')
+endpoint_url = os.getenv('BUCKET_URL', 'https://sfo2.digitaloceanspaces.com')
+aws_access_key_id = os.getenv('BUCKET_ACCESS_KEY')
+aws_secret_access_key = os.getenv('BUCKET_SECRET_ACCESS_KEY')
+bucket_name = os.getenv('BUCKET_NAME', 'pollination')
+bucket_url_expiration = int(os.getenv('BUCKET_URL_EXPIRATION', '3600'))
+
+session = boto3.session.Session()
+client = session.client('s3',
+                        region_name=region_name,
+                        endpoint_url=endpoint_url,
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key)
+
+
+def get_upload_url(user_id, file_name, bucket=bucket_name):
+    key = 'users/{user_id}/uploads/{file_name}'.format(user_id=user_id, file_name=file_name)
+    url = client.generate_presigned_url('put_object',
+                                        Params={'Bucket': bucket, 'Key':key},
+                                        ExpiresIn=bucket_url_expiration,
+                                        HttpMethod='PUT')
+    return url
+
+def list_files(user_id, bucket=bucket_name):
+    prefix = 'users/{}/uploads/'.format(user_id)
+    response = client.list_objects(Bucket=bucket, Prefix=prefix)
+    if response.get('ResponseMetadata').get('HTTPStatusCode') == 200:
+        contents = response.get('Contents')
+        if contents is not None:
+            files = [content['Key'] for content in contents]
+        else:
+            files = []
+        return files
+    else:
+        print(response) # log error to be captured through stdout logging system
+        raise Exception('Something went wrong when fetching data from buckets')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,10 @@ astroid==2.1.0
 atomicwrites==1.3.0
 attrs==18.2.0
 black==18.9b0
+boto3==1.9.91
+botocore==1.12.91
 Click==7.0
+docutils==0.14
 Flask==1.0.2
 Flask-Migrate==2.3.1
 flask-restplus==0.12.1
@@ -13,6 +16,7 @@ Flask-SQLAlchemy==2.3.2
 isort==4.3.4
 itsdangerous==1.1.0
 Jinja2==2.10
+jmespath==0.9.3
 jsonschema==2.6.0
 lazy-object-proxy==1.3.1
 Mako==1.0.7
@@ -22,12 +26,15 @@ more-itertools==5.0.0
 pluggy==0.8.1
 psycopg2==2.7.7
 py==1.7.0
+pylint==2.2.2
 python-dateutil==2.7.5
 python-editor==1.0.4
 pytz==2018.9
+s3transfer==0.2.0
 six==1.12.0
 SQLAlchemy==1.2.17
 toml==0.10.0
 typed-ast==1.3.0
+urllib3==1.24.1
 Werkzeug==0.14.1
 wrapt==1.11.1

--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,5 @@
-apiVersion: serving.knative.dev/v1alpha1
-kind: Service
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: {{REPOSITORY}}
   namespace: {{NAMESPACE}}
@@ -7,43 +7,65 @@ metadata:
     app: api
     microservice: {{REPOSITORY}}
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{{ORG}}/{{REPOSITORY}}:{{COMMIT_TAG}}
-            env:
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: db-user
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: db-password
-            - name: DB_SERVER
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: db-server
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: db-port
-            - name: BUCKET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: bucket-access-key
-            - name: BUCKET_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: service-secrets
-                  key: bucket-secret-access-key
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: api
+        microservice: {{REPOSITORY}}
+    spec:
+      containers:
+        - name: {{REPOSITORY}}
+          image: docker.io/{{ORG}}/{{REPOSITORY}}:{{COMMIT_TAG}}
+          env:
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: db-user
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: db-password
+          - name: DB_SERVER
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: db-server
+          - name: DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: db-port
+          - name: BUCKET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: bucket-access-key
+          - name: BUCKET_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: service-secrets
+                key: bucket-secret-access-key
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{REPOSITORY}}
+  namespace: {{NAMESPACE}}
+  labels:
+    app: api
+    microservice: {{REPOSITORY}}
+spec:
+  selector:
+    app: api
+    microservice: {{REPOSITORY}}
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -55,16 +77,15 @@ metadata:
     microservice: {{REPOSITORY}}
 spec:
   gateways:
-  - knative-shared-gateway.knative-serving.svc.cluster.local
+    - api-gateway
   hosts:
-  - api.pollination.cloud
+    - "*"
   http:
-  - match:
-    - uri:
-        prefix: "/{{ENDPOINT}}"
-    rewrite:
-      authority: {{REPOSITORY}}.{{NAMESPACE}}.api.pollination.cloud
-    route:
-    - destination:
-        host: knative-ingressgateway.istio-system.svc.cluster.local
-      weight: 100
+    - match:
+        - uri:
+            prefix: "/{{ENDPOINT}}"
+      route:
+        - destination:
+            port:
+              number: 80
+            host: {{REPOSITORY}}

--- a/service.yml
+++ b/service.yml
@@ -29,6 +29,11 @@ spec:
                 secretKeyRef:
                   name: service-secrets
                   key: db-server
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: db-port
             - name: BUCKET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/service.yml
+++ b/service.yml
@@ -14,8 +14,31 @@ spec:
           container:
             image: docker.io/{{ORG}}/{{REPOSITORY}}:{{COMMIT_TAG}}
             env:
-            - name: TARGET
-              value: "Python Sample v1"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: db-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: db-password
+            - name: DB_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: db-server
+            - name: BUCKET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: bucket-access-key
+            - name: BUCKET_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: service-secrets
+                  key: bucket-secret-access-key
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService


### PR DESCRIPTION
This PR demonstrates how to add Object Storage support through the S3 http API. This API has a standard client called `boto3` which facilitates authentication and interaction with object storage servers.

Here is a [link](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html) to the essential documentation for this api client.